### PR TITLE
fix: add permissions block to workflow for security

### DIFF
--- a/.github/workflows/rls-guard.yml
+++ b/.github/workflows/rls-guard.yml
@@ -1,4 +1,6 @@
 name: RLS Guard
+permissions:
+  contents: read
 on:
   pull_request:
     branches: [ main ]


### PR DESCRIPTION
## Summary
Fixes CodeQL security alert about missing workflow permissions.

## Security Issue
- **Alert**: actions/missing-workflow-permissions
- **Location**: .github/workflows/rls-guard.yml:7
- **Problem**: Workflow doesn't explicitly declare GITHUB_TOKEN permissions

## Solution
Add explicit permissions block limiting token to read-only access:
- Sets `contents: read` permission
- Follows principle of least privilege
- Prevents potential token abuse

## Verification
- ✅ Security alert will be resolved after merge
- ✅ Workflow still functions correctly (only needs read access)
- ✅ No breaking changes

Closes security alert #3


> [!NOTE]
> I'm currently writing a description for your pull request. I should be done shortly (<1 minute). Please don't edit the description field until I'm finished, or we may overwrite each other. If I find nothing to write about, I'll delete this message.

## Summary by Sourcery

Add explicit permissions block to the rls-guard GitHub Actions workflow to grant read-only content access for GITHUB_TOKEN and resolve the missing-workflow-permissions security alert.

Bug Fixes:
- Resolve actions/missing-workflow-permissions alert by explicitly declaring GITHUB_TOKEN permissions

CI:
- Add permissions: contents: read to the .github/workflows/rls-guard.yml workflow