### PR TITLE
fix: add permissions to assessment-quality workflow

### DIFF
--- a/.github/workflows/assessment-quality.yml
+++ b/.github/workflows/assessment-quality.yml
@@ -1,5 +1,7 @@
 # IPE Pillar 7: Implementation-ready CI/CD guardrails
 name: Assessment Quality Assurance
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
## Summary
Fixes the final CodeQL security alert about missing workflow permissions.

## Security Issue
- **Alert**: actions/missing-workflow-permissions
- **Location**: .github/workflows/assessment-quality.yml:20
- **Problem**: Workflow doesn't explicitly declare GITHUB_TOKEN permissions

## Solution
Add explicit permissions block limiting token to read-only access:
- Sets `contents: read` permission
- Follows principle of least privilege
- Prevents potential token abuse

## Verification
- ✅ Security alert will be resolved after merge
- ✅ Workflow still functions correctly (only needs read access)
- ✅ No breaking changes
- ✅ This is the last remaining security alert

Closes security alert #2

## Summary by Sourcery

Add explicit permissions to the assessment-quality GitHub Actions workflow to resolve the missing-workflow-permissions security alert and restrict GITHUB_TOKEN to read-only contents.

Bug Fixes:
- Resolve actions/missing-workflow-permissions CodeQL security alert by declaring GITHUB_TOKEN permissions.

Enhancements:
- Restrict workflow’s GITHUB_TOKEN to contents: read following the principle of least privilege.